### PR TITLE
New minimal numbering design

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,16 @@ can be customized with:
 \footlineinfo{Custom footline text}
 ```
 
+For both footline numberings the full page numbering can be deactivated via `fullpagenumbering=no` as an option in theme selection. The standard value is `yes`.
+```latex
+\usetheme[fullpagenumbering=no]{focus}
+```
+
 The footline may also be disabled globally by typing:
 ```latex
 \usetheme[numbering=none]{focus}
 ```
+
 
 Customize fonts
 ---------------

--- a/README.md
+++ b/README.md
@@ -63,13 +63,7 @@ Alternatively, a full footline bar with the frame numbering can be shown with:
 ```latex
 \usetheme[numbering=fullbar]{focus}
 ```
-
-or in a more minimal version only display the current frame number using:
-```latex
-\usetheme[numbering=minimal]{focus}
-```
-
-In both cases, an optional text to be printed on the left side of the footline
+In such case, an optional text to be printed on the left side of the footline
 can be customized with:
 ```latex
 \footlineinfo{Custom footline text}

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ can be customized with:
 \footlineinfo{Custom footline text}
 ```
 
-For both footline numberings the full page numbering can be deactivated via `fullpagenumbering=no` as an option in theme selection. The standard value is `yes`.
+For both footline numberings the total frame numbering can be deactivated via `totalframenumbering=no` as an option in theme selection. The standard value is `yes`.
 ```latex
-\usetheme[fullpagenumbering=no]{focus}
+\usetheme[totalframenumbering=no]{focus}
 ```
 
 The footline may also be disabled globally by typing:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ Alternatively, a full footline bar with the frame numbering can be shown with:
 ```latex
 \usetheme[numbering=fullbar]{focus}
 ```
-In such case, an optional text to be printed on the left side of the footline
+
+or in a more minimal version only display the current frame number using:
+```latex
+\usetheme[numbering=minimal]{focus}
+```
+
+In both cases, an optional text to be printed on the left side of the footline
 can be customized with:
 ```latex
 \footlineinfo{Custom footline text}

--- a/beamerouterthemefocus.sty
+++ b/beamerouterthemefocus.sty
@@ -68,6 +68,9 @@
 \newlength{\focus@pbar@leftoffset}
 \newlength{\focus@pbar@rightoffset}
 
+% Comparision token for totalframenumbering
+\def\no{no}
+
 \defbeamertemplate*{footline}{progressbar}{%
     % If not appendix.
     \ifnum\mainend<0% From package appendixnumberbeamer.
@@ -92,7 +95,11 @@
                                        ++(0,{-0.5*\the\focus@pbar@height}) node[anchor=east, text=footline.fg] {\strut\insertframenumber};
                     
                     \fill[footline.bg] (\paperwidth,0) rectangle ++(-\the\focus@pbar@rightoffset,\the\focus@pbar@height)
-                                       ++(0,{-0.5*\the\focus@pbar@height}) node[anchor=west, text=footline.fg] {\strut\inserttotalframenumber};
+                                       ++(0,{-0.5*\the\focus@pbar@height}) node[anchor=west, text=footline.fg]
+                                       {\ifx\beamer@focus@totalframenumbering\no
+                                        \else
+                                            \strut\inserttotalframenumber
+                                        \fi};
                 \end{tikzpicture}%
             \else%
                 \begin{tikzpicture}[inner xsep=0.5em, inner ysep=0.5ex]
@@ -100,8 +107,13 @@
                     \fill[footline.bg] (0,0) rectangle ++(\paperwidth,\the\focus@pbar@height);
                     
                     \node[anchor=east, footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut\insertframenumber};
-                    \node[footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut/};
-                    \node[anchor=west, footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut\inserttotalframenumber};
+
+
+                    \ifx\beamer@focus@totalframenumbering\no
+                    \else
+                        \node[footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut/};
+                        \node[anchor=west, footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut\inserttotalframenumber};
+                    \fi
                 \end{tikzpicture}%
             \fi%
         \fi%
@@ -118,8 +130,12 @@
         \settowidth{\focus@pbar@leftoffset}{1}%
         \addtolength{\focus@pbar@leftoffset}{1.5em}%
         %
-        \settowidth{\focus@pbar@rightoffset}{\inserttotalframenumber}%
-        \addtolength{\focus@pbar@rightoffset}{1.5em}%
+        \ifx\beamer@focus@totalframenumbering\no
+            \addtolength{\focus@pbar@rightoffset}{.5em}%
+        \else
+            \settowidth{\focus@pbar@rightoffset}{\inserttotalframenumber}%
+            \addtolength{\focus@pbar@rightoffset}{1.5em}%
+        \fi
         %
         % If not title page.
         \ifnum\value{realframenumber}>0%
@@ -133,8 +149,12 @@
                 \fi
 
                 \node[anchor=east, footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut\insertframenumber};
-                \node[footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut/};
-                \node[anchor=west, footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut\inserttotalframenumber};
+
+                \ifx\beamer@focus@totalframenumbering\no
+                \else
+                    \node[footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut/};
+                    \node[anchor=west, footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut\inserttotalframenumber};
+                \fi
             \end{tikzpicture}%
         \fi%
     \fi%
@@ -172,12 +192,16 @@
 
 \DeclareOptionBeamer{numbering}{\def\beamer@focus@numbering{#1}}
 \ExecuteOptionsBeamer{numbering=progressbar}
+\DeclareOptionBeamer{totalframenumbering}{\def\beamer@focus@totalframenumbering{#1}}
+\ExecuteOptionsBeamer{totalframenumbering=yes}
 \ProcessOptionsBeamer
 
 \def\beamer@focus@numberingprogressbar{progressbar}
 \def\beamer@focus@numberingfullbar{fullbar}
-\def\beamer@focus@numberingminimal{minimal}
 \def\beamer@focus@numberingnone{none}
+
+\def\beamer@focus@totalframenumberingyes{yes}
+\def\beamer@focus@totalframenumberingno{no}
 
 
 % BACKGROUND CANVAS TEMPLATES. -------------------------------------------------
@@ -217,11 +241,7 @@
             \ifx\beamer@focus@numbering\beamer@focus@numberingfullbar%
                 \setbeamertemplate{footline}[fullbar]%
             \else%
-                \ifx\beamer@focus@numbering\beamer@focus@numberingminimal%
-                    \setbeamertemplate{footline}[minimal]%
-                \else%
-                    \setbeamertemplate{footline}[none]%
-                \fi%
+                \setbeamertemplate{footline}[none]%
             \fi%
         \fi%
         %

--- a/beamerouterthemefocus.sty
+++ b/beamerouterthemefocus.sty
@@ -160,33 +160,6 @@
     \fi%
 }
 
-% Minimal fullbar footline.
-\def\footlineinfo#1{\def\focus@footlineinfo{#1}}
-\footlineinfo{} % Empty by default.
-\defbeamertemplate{footline}{minimal}{%
-    % If not appendix.
-    \ifnum\mainend<0% From package appendixnumberbeamer.
-        %
-        \settowidth{\focus@pbar@leftoffset}{1}%
-        \addtolength{\focus@pbar@leftoffset}{1.5em}%
-        %
-        % If not title page.
-        \ifnum\value{realframenumber}>0%
-            \begin{tikzpicture}[inner xsep=0.5em, inner ysep=0.5ex]
-                \clip (0,0) rectangle ++(\paperwidth,\the\focus@pbar@height);
-                \fill[footline.bg] (0,0) rectangle ++(\paperwidth,\the\focus@pbar@height);
-
-                \ifx\focus@footlineinfo\empty
-                \else
-                    \node[anchor=west, footline.fg] at ({\the\focus@pbar@leftoffset},{0.5*\focus@pbar@height}) {\focus@footlineinfo};
-                \fi
-
-                \node[anchor=east, footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut\insertframenumber};
-            \end{tikzpicture}%
-        \fi%
-    \fi%
-}
-
 % Empty footline.
 \defbeamertemplate{footline}{none}{}
 

--- a/beamerouterthemefocus.sty
+++ b/beamerouterthemefocus.sty
@@ -140,6 +140,33 @@
     \fi%
 }
 
+% Minimal fullbar footline.
+\def\footlineinfo#1{\def\focus@footlineinfo{#1}}
+\footlineinfo{} % Empty by default.
+\defbeamertemplate{footline}{minimal}{%
+    % If not appendix.
+    \ifnum\mainend<0% From package appendixnumberbeamer.
+        %
+        \settowidth{\focus@pbar@leftoffset}{1}%
+        \addtolength{\focus@pbar@leftoffset}{1.5em}%
+        %
+        % If not title page.
+        \ifnum\value{realframenumber}>0%
+            \begin{tikzpicture}[inner xsep=0.5em, inner ysep=0.5ex]
+                \clip (0,0) rectangle ++(\paperwidth,\the\focus@pbar@height);
+                \fill[footline.bg] (0,0) rectangle ++(\paperwidth,\the\focus@pbar@height);
+
+                \ifx\focus@footlineinfo\empty
+                \else
+                    \node[anchor=west, footline.fg] at ({\the\focus@pbar@leftoffset},{0.5*\focus@pbar@height}) {\focus@footlineinfo};
+                \fi
+
+                \node[anchor=east, footline.fg] at ({\paperwidth-\the\focus@pbar@rightoffset},{0.5*\focus@pbar@height}) {\strut\insertframenumber};
+            \end{tikzpicture}%
+        \fi%
+    \fi%
+}
+
 % Empty footline.
 \defbeamertemplate{footline}{none}{}
 
@@ -149,6 +176,7 @@
 
 \def\beamer@focus@numberingprogressbar{progressbar}
 \def\beamer@focus@numberingfullbar{fullbar}
+\def\beamer@focus@numberingminimal{minimal}
 \def\beamer@focus@numberingnone{none}
 
 
@@ -189,7 +217,11 @@
             \ifx\beamer@focus@numbering\beamer@focus@numberingfullbar%
                 \setbeamertemplate{footline}[fullbar]%
             \else%
-                \setbeamertemplate{footline}[none]%
+                \ifx\beamer@focus@numbering\beamer@focus@numberingminimal%
+                    \setbeamertemplate{footline}[minimal]%
+                \else%
+                    \setbeamertemplate{footline}[none]%
+                \fi%
             \fi%
         \fi%
         %

--- a/beamerthemefocus.sty
+++ b/beamerthemefocus.sty
@@ -29,6 +29,10 @@
     \PassOptionsToPackage{numbering=#1}{beamerouterthemefocus}
 }
 
+\DeclareOptionBeamer{totalframenumbering}{%
+    \PassOptionsToPackage{totalframenumbering=#1}{beamerouterthemefocus}
+}
+
 \newif\if@focus@loadfirafonts
 \@focus@loadfirafontstrue
 

--- a/focus-demo.tex
+++ b/focus-demo.tex
@@ -11,7 +11,7 @@
 \institute{Institute Name \\ Institute Address}
 \date{dd mm yyyy}
 
-% Footline info is printed only if [numbering=fullbar].
+% Footline info is printed only if [numbering=fullbar] or [numbering=minimal].
 %\footlineinfo{Custom footline text}
 
 \begin{document}

--- a/focus-demo.tex
+++ b/focus-demo.tex
@@ -11,7 +11,7 @@
 \institute{Institute Name \\ Institute Address}
 \date{dd mm yyyy}
 
-% Footline info is printed only if [numbering=fullbar] or [numbering=minimal].
+% Footline info is printed only if [numbering=fullbar].
 %\footlineinfo{Custom footline text}
 
 \begin{document}


### PR DESCRIPTION
Last week I tried out a new numbering style to use in a presentation and decided to add it also as a new `minimal` style to the theme.

The idea behind this new style to have less visual change between two content slides while still having a current frame number for the audience to refer to. It is only a small adaptation of the `fullbar` numbering, deleting everything, which is not needed. It still holds the capacity to add a custom `footlineinfo` text, if wanted.

I hope I found all parts in the theme, where changes were necessary. Happy to hear feedback.

![Minimal Design](https://user-images.githubusercontent.com/11877115/145031049-1c8d60f6-1283-430e-b56b-314b0a115185.png)
![Minimal Design with footlineinfo](https://user-images.githubusercontent.com/11877115/145031057-1ac09963-6f77-462a-9359-ed53ead36c40.png)
