### PR TITLE
Fix frame numbering on frames with noframenumbering and allowframebreaks option

### DIFF
--- a/beamerouterthemefocus.sty
+++ b/beamerouterthemefocus.sty
@@ -205,6 +205,11 @@
 % Empty footline.
 \defbeamertemplate{footline}{none}{}
 
+% Empty footline for noframenumbering.
+\defbeamertemplate{footline}{noframenumbering}{
+    \addtocounter{framenumber}{-1}
+}
+
 \DeclareOptionBeamer{numbering}{\def\beamer@focus@numbering{#1}}
 \ExecuteOptionsBeamer{numbering=progressbar}
 
@@ -276,8 +281,6 @@
     \setbeamertemplate{footline}[none]%
     \setlength{\focus@pbar@height}{0cm}%
     \focus@calculatefootheight%
-    %
-    \addtocounter{framenumber}{-1}%
 }
 
 


### PR DESCRIPTION
If you combine the noframenumbering option with allowframebreaks, all frames after the first one are numbered again. 
This change solved it for me, by moving the counter correction into the footline instead of the option definition.