### PR TITLE
Update opacity of footline bar in minimal setting

### DIFF
--- a/beamerouterthemefocus.sty
+++ b/beamerouterthemefocus.sty
@@ -183,7 +183,7 @@
         \ifnum\value{realframenumber}>0%
         \begin{tikzpicture}[inner xsep=0.5em, inner ysep=0.5ex]
             \clip (0,0) rectangle ++(\paperwidth,\the\focus@pbar@height);
-            \fill[footline.fg] (0,0) rectangle ++(\paperwidth,\the\focus@pbar@height);
+            \fill[footline.fg, opacity=0, text opacity=1] (0,0) rectangle ++(\paperwidth,\the\focus@pbar@height);
 
             \ifx\focus@footlineinfo\empty%
             \else%


### PR DESCRIPTION
This renders the footer bar transparent to not cut off any text or included graphics at the usual footline height. Added explicit text opacity = 1 to render text visible.
Sorry not sorry for cluttering my slides with plots as large as possible :laughing: